### PR TITLE
stringify frames per as_string (#19)

### DIFF
--- a/lib/Devel/StackTrace/Frame.pm
+++ b/lib/Devel/StackTrace/Frame.pm
@@ -3,6 +3,8 @@ package Devel::StackTrace::Frame;
 use strict;
 use warnings;
 
+use DDP;
+
 our $VERSION = '2.04';
 
 # Create accessor routines
@@ -27,6 +29,11 @@ BEGIN {
         *{$a} = sub { my $s = shift; return $s->{$a} };
     }
 }
+
+# XXX -- Arguments are garbled if giving overload \&as_string or 'as_string' directly.
+use overload
+    '""'     => sub { $_[0]->as_string },
+    fallback => 1;
 
 {
     my @args = qw(

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -399,6 +399,15 @@ SKIP:
     );
 }
 
+# Stringification of frame
+{
+    my $frame = quux()->frame(0);
+    is(
+        "$frame", $frame->as_string, 
+        'frame stringification'
+    );
+}
+
 done_testing();
 
 # This means I can move these lines down without constantly fiddling


### PR DESCRIPTION
See #19.

I had to give overload an anonymous sub which calls `as_string` on the object rather than giving it `\&as_string` or `'as_string'` or arguments wouldn't be shown properly in the stringification.  Probably because of generated accessors which don't exist yet?

I added a very basic test checking that the stringification is identical to the return value of `$frame->as_string`.  It caught the above problem so apparently not too simple!