### PR TITLE
Add workaround for Bizarre copy errors

### DIFF
--- a/lib/Devel/StackTrace.pm
+++ b/lib/Devel/StackTrace.pm
@@ -57,8 +57,33 @@ sub _record_caller_data {
 
         my @args;
 
-        ## no critic (Variables::ProhibitPackageVars)
-        @args = $self->{no_args} ? () : @DB::args;
+        ## no critic (Variables::ProhibitPackageVars, BuiltinFunctions::ProhibitComplexMappings)
+        unless ( $self->{no_args} ) {
+            # Usage same workaroud as in Carp.pm:
+            #   Guard our serialization of the stack from stack refcounting bugs
+            #   NOTE this is NOT a complete solution, we cannot 100% guard against
+            #   these bugs.  However in many cases Perl *is* capable of detecting
+            #   them and throws an error when it does.  Unfortunately serializing
+            #   the arguments on the stack is a perfect way of finding these bugs,
+            #   even when they would not affect normal program flow that did not
+            #   poke around inside the stack.  Inside of Carp.pm it makes little
+            #   sense reporting these bugs, as Carp's job is to report the callers
+            #   errors, not the ones it might happen to tickle while doing so.
+            #   See: https://rt.perl.org/Public/Bug/Display.html?id=131046
+            #   and: https://rt.perl.org/Public/Bug/Display.html?id=52610
+            #   for more details and discussion. - Yves
+            @args = map {
+                my $arg;
+                local $@ = $@;
+                eval {
+                    $arg = $_;
+                    1;
+                } or do {
+                    $arg = '** argument not available anymore **';
+                };
+                $arg;
+            } @DB::args;
+        }
         ## use critic
 
         my $raw = {


### PR DESCRIPTION
Same workaround was added to Carp.pm module based on patch:
https://rt.perl.org/Public/Bug/Display.html?id=131046

It is not fix just a workaround which may work.

See also:
https://github.com/houseabsolute/Devel-StackTrace/issues/11
https://rt.perl.org/Public/Bug/Display.html?id=52610